### PR TITLE
Fix: frontend 디렉터리에서 `npm install` 자동 실행되도록 수정

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,8 +27,12 @@ COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 
 # Node.js 패키지 설치
-COPY package.json .
+COPY frontend/package.json .
+COPY frontend/package-lock.json .
 RUN npm install
+
+# 소스 파일 복사
+COPY . .
 
 # Port 명시
 EXPOSE 8080


### PR DESCRIPTION
**Dockerfile을 업데이트**하여 **`npm install`이 /container/frontend 디렉터리에서 실행되도록 작업 디렉터리를 변경**했습니다.
이를 통해 Node.js 의존성이 frontend 디렉터리에 올바르게 설치되며, 수동 설치가 필요하지 않게 됩니다.